### PR TITLE
fix: Use spawn instead of exec

### DIFF
--- a/lint-filter.js
+++ b/lint-filter.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 require('babel-polyfill')
-require('./lib').default()
+require('./lib').default() // eslint-disable-line import/no-unresolved

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -2,7 +2,26 @@ import _ from 'lodash'
 import cp from 'child_process'
 import Promise from 'bluebird'
 
-export const execFile = Promise.promisify(cp.execFile)
+export const spawn = (file, args) => new Promise((resolve, reject) => {
+  let stdout = ''
+  let stderr = ''
+
+  const process = cp.spawn(file, args)
+  process.stdout.on('data', data => { stdout += data })
+  process.stderr.on('data', data => { stderr += data })
+
+  process.on('close', code => {
+    if (code === 0) {
+      resolve(stdout)
+    } else {
+      const error = new Error(`${file} ${args.join(' ')} failed`)
+      error.stdout = stdout
+      error.stderr = stderr
+      error.code = code
+      reject(error)
+    }
+  })
+})
 
 export function parseDiffRanges(diff) {
   const matches = diff.match(/^@@ -\d+,\d+ \+(\d+),(\d+) @@/gm)
@@ -37,6 +56,6 @@ export function parseFullDiff(diff) {
 }
 
 export async function getDiffInformation({ branch = 'origin/master', hash } = {}) {
-  const diffAgainst = hash || await exports.execFile('git', ['merge-base', branch, 'HEAD'])
-  return parseFullDiff(await exports.execFile('git', ['diff', diffAgainst.trim()]))
+  const diffAgainst = hash || await exports.spawn('git', ['merge-base', branch, 'HEAD'])
+  return parseFullDiff(await exports.spawn('git', ['diff', diffAgainst.trim()]))
 }

--- a/test/parser_tests.js
+++ b/test/parser_tests.js
@@ -1,4 +1,41 @@
 import test from 'ava'
-import parser from '../src/parser' // eslint-disable-line
+import sinon from 'sinon'
 
-test.todo('write tests')
+import * as parser from '../src/parser' // eslint-disable-line
+
+test.serial('parseFile(path) should read file and call parseString', async t => {
+  sinon.stub(parser, 'readFile').returns(Promise.resolve('content'))
+  sinon.stub(parser, 'parseString').returns(Promise.resolve('parsed'))
+
+  const parsed = await parser.parseFile('path')
+  t.is(parsed, 'parsed')
+  t.is(parser.parseString.args[0][0], 'content')
+
+  parser.readFile.restore()
+  parser.parseString.restore()
+})
+
+const parseStringResult = [
+  { line: '7', column: '23', severity: 'error', message: 'Extra semicolon. (semi)',
+    source: 'eslint.rules.semi', file: '/Users/rolf/dev/lint-filter/README.md' },
+  { line: '7', column: '23', severity: 'error', message: 'Extra semicolon. (semi)',
+    source: 'eslint.rules.semi', file: '/Users/rolf/dev/lint-filter/src/index.js' },
+  { line: '7', column: '23', severity: 'error', message: 'Extra semicolon. (semi)',
+    source: 'eslint.rules.semi', file: '/Users/rolf/dev/lint-filter/src/index.js' },
+]
+
+test.serial('parseString(str) should parse xml', async t => {
+  const xml = await parser.readFile('./fixtures/eslint/extra-semi.xml')
+  const parsed = await parser.parseString(xml.toString())
+  t.deepEqual(parsed, parseStringResult, JSON.stringify(parsed))
+})
+
+test.serial('parseFiles(files) should call parseFile and flatten out the result ', async t => {
+  sinon.stub(parser, 'parseFile').returns(Promise.resolve(parseStringResult))
+  const result = await parser.parseFiles([
+    './fixtures/eslint/extra-semi.xml',
+    './fixtures/eslint/extra-semi.xml',
+  ])
+
+  t.deepEqual(result, [...parseStringResult, ...parseStringResult])
+})

--- a/test/utils/git_tests.js
+++ b/test/utils/git_tests.js
@@ -41,7 +41,7 @@ test.serial(
   'getDiffInformation({branch, hash}) should return object with diff ranges for all files',
   async (t) => {
     t.plan(1)
-    t.context.sandbox.stub(gitUtils, 'execFile').returns(Promise.resolve(diffFixture))
+    t.context.sandbox.stub(gitUtils, 'spawn').returns(Promise.resolve(diffFixture))
     const diff = await gitUtils.getDiffInformation()
 
     t.deepEqual(diff, {
@@ -57,11 +57,11 @@ test.serial(
   'getDiffInformation({branch, hash}) should use origin/master as default',
   async (t) => {
     t.plan(1)
-    t.context.sandbox.stub(gitUtils, 'execFile').returns(Promise.resolve(diffFixture))
+    t.context.sandbox.stub(gitUtils, 'spawn').returns(Promise.resolve(diffFixture))
     await gitUtils.getDiffInformation({})
 
     t.deepEqual(
-      gitUtils.execFile.getCall(0).args,
+      gitUtils.spawn.getCall(0).args,
       ['git', ['merge-base', 'origin/master', 'HEAD']]
     )
   }
@@ -71,11 +71,11 @@ test.serial(
   'getDiffInformation({branch, hash}) should use custom branch when specified',
   async (t) => {
     t.plan(1)
-    t.context.sandbox.stub(gitUtils, 'execFile').returns(Promise.resolve(diffFixture))
+    t.context.sandbox.stub(gitUtils, 'spawn').returns(Promise.resolve(diffFixture))
     await gitUtils.getDiffInformation({ branch: 'origin/production' })
 
     t.deepEqual(
-      gitUtils.execFile.getCall(0).args,
+      gitUtils.spawn.getCall(0).args,
       ['git', ['merge-base', 'origin/production', 'HEAD']]
     )
   }


### PR DESCRIPTION
This is to support larger chunks of diff than exec allowed us to have.