### PR TITLE
fix: Only check modified lines

### DIFF
--- a/integration-test
+++ b/integration-test
@@ -23,6 +23,14 @@ function print_success() {
 
 if cat eslint-result.xml | ./lint-filter.js; then
   print_error "stdin test"
+elif [[ $(cat eslint-result.xml | ./lint-filter.js | grep -oc "no-console") != "1" ]]; then
+  print_error "stdin output"
+else
+  print_success "args"
+fi
+
+if cat eslint-result.xml | ./lint-filter.js; then
+  print_error "stdin test"
 elif [[ $(cat eslint-result.xml | ./lint-filter.js | grep -oc "semi") != "1" ]]; then
   print_error "stdin output"
 else

--- a/test/utils/git_tests.js
+++ b/test/utils/git_tests.js
@@ -17,20 +17,29 @@ test('parseDiffRanges(diff) should return empty array for no matches', t => {
 })
 
 test('parseDiffRanges(diff) should return diff range for one match', t => {
-  t.deepEqual(gitUtils.parseDiffRanges('@@ -0,0 +1,2 @@'), [[1, 3]])
-  t.deepEqual(gitUtils.parseDiffRanges('@@ -0,0 +14,20 @@'), [[14, 34]])
+  const diff = `
++++ b/src/gitUtils.js
+@@ -0,0 +1,2 @@
++const exec = Promise.promisify(cp.exec)
++export function parseDiffRanges(diff) {
++const matches = diff.match(/\@\@ -\d+,\d+ \+(\d+),(\d+) \@\@/g)
+  `
+  t.deepEqual(gitUtils.parseDiffRanges(diff), [[1, 3]])
 })
 
 test('parseDiffRanges(diff) should return diff range for multiple matches', t => {
   const diff = `
 +++ b/src/gitUtils.js
 @@ -8,27 +8,43 @@
-const exec = Promise.promisify(cp.exec)
-export function parseDiffRanges(diff) {
++const exec = Promise.promisify(cp.exec)
++export function parseDiffRanges(diff) {
 const matches = diff.match(/\@\@ -\d+,\d+ \+(\d+),(\d+) \@\@/g)
 @@ -0,0 +45,55 @@
+const exec = Promise.promisify(cp.exec)
+export function parseDiffRanges(diff) {
++const matches = diff.match(/\@\@ -\d+,\d+ \+(\d+),(\d+) \@\@/g)
   `
-  t.deepEqual(gitUtils.parseDiffRanges(diff), [[8, 51], [45, 100]])
+  t.deepEqual(gitUtils.parseDiffRanges(diff), [[8, 9], [47, 47]])
 })
 
 test(
@@ -46,10 +55,13 @@ test.serial(
     const diff = await gitUtils.getDiffInformation()
 
     t.deepEqual(diff, {
-      'lint-filter.js': [[1, 3], [2, 5]],
-      'src/index.js': [[4, 17]],
-      'src/utils.js': [[3, 44], [45, 52], [60, 67]],
-      'test/utils_tests.js': [[40, 65], [74, 122]],
+      'lint-filter.js': [],
+      'src/index.js': [[7, 7], [13, 13]],
+      'src/utils.js': [
+        [6, 7], [10, 10], [13, 13], [20, 20], [27, 33],
+        [35, 36], [39, 40], [48, 48], [63, 66],
+      ],
+      'test/utils_tests.js': [[43, 45], [47, 47], [50, 58], [61, 61], [77, 121]],
     })
   }
 )


### PR DESCRIPTION
Hello,

Currently this module do not strictly check the modified lines but it checks all lines that are present in the diff.

For example, given this diff (from `test/fixtures/dummy.patch`)

```diff
diff --git a/test/fixtures/dummy.js b/test/fixtures/dummy.js
index 973b39f..abbf972 100644
--- a/test/fixtures/dummy.js
+++ b/test/fixtures/dummy.js
@@ -3,7 +3,7 @@
 const coffee = '☕'
 
 if (typeof coffee === 'string') {
-  console.log('\o/')
+  console.log('\o/');
 }
 
 console.log('----------')
```

lint-filter will report errors from lines 6 (`console.log('\o/');`) and 9 (`console.log('----------')`) even if only the line 6 was modified. You can reproduce the problem by running `integration-test`.

This can be problematic if you have a lot of errors in your files and just want to progressively fix them.

This patch update `parseDiffRanges()` to only check the modified lines.

I added a new test in `integration-test` to check that we only have 1 warning about console.log (for line 6). I also had to update `parseDiffRanges()` tests in `git_tests.js` since its output is different (same format but more precise ranges).

Finally, a big Thank You for this module (I discovered it during your talk at dotJS 2016), it really helps us for migrating our existing codebase to a stricter style without making our developers (too) mad :heart: 