### PR TITLE
Update text formatter to display a different icon for warnings

### DIFF
--- a/src/formatters/text.js
+++ b/src/formatters/text.js
@@ -6,9 +6,10 @@ import type { OutputFormat, Stats } from './'
 
 function resultText(result) {
   return _.map(result, file => {
-    const messages = _.map(file.messages, message =>
-      `  ✖ ${chalk.gray(`${message.line}:${message.column}`)} ${message.message}\n`
-    ).join('')
+    const messages = _.map(file.messages, message => {
+      const icon = message.severity === 'warning' ? chalk.yellow('⚠') : chalk.red('✖')
+      return `  ${icon} ${chalk.gray(`${message.line}:${message.column}`)} ${message.message}\n`
+    }).join('')
     return `${chalk.underline(`File: ${file.filename}`)}\n${messages}`
   }).join('')
 }

--- a/test/formatters/text_tests.js
+++ b/test/formatters/text_tests.js
@@ -27,7 +27,7 @@ const stats = {
 
 const output = (
   '\u001b[4mFile: ~/dev/lint-filter/src/index.js\u001b[24m\n' +
-  '  ✖ \u001b[90m7:23\u001b[39m Extra semicolon. (semi)\n' +
+  '  \u001b[31m✖\u001b[39m \u001b[90m7:23\u001b[39m Extra semicolon. (semi)\n' +
   '\n1 of 10 errors and 3 of 11 warnings'
 )
 


### PR DESCRIPTION
As discussed in https://github.com/relekang/lint-filter/pull/77, I updated the text formatter to display a different icon for warnings ⚠ and errors ✖.

I also added some colors (yellow for warnings and red for errors) to make them more visually distinguishable.

Example output:

![](http://i.imgur.com/91C7PUe.png)