### PR TITLE
Fix wrong file names if path is relative

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -16,7 +16,8 @@ export type CheckstyleItem = {
 export const readFile = Promise.promisify(fs.readFile)
 
 export function makePathRelative(filepath: string): string {
-  return filepath.replace(`${process.cwd()}`, '').replace(/\\/g, '/').slice(1)
+  const path = filepath.replace(`${process.cwd()}`, '').replace(/\\/g, '/')
+  return path.substr(0, 1) === '/' ? path.substr(1) : path
 }
 
 export function mapErrorsFromFileBlock(file: Object) {

--- a/test/fixtures/eslint/dummy_js_windows.xml
+++ b/test/fixtures/eslint/dummy_js_windows.xml
@@ -7,4 +7,7 @@
     <error line="9" column="1" severity="warning" message="Unexpected console statement. (no-console)" source="eslint.rules.no-console" />
     <error line="11" column="14" severity="error" message="Extra semicolon. (semi)" source="eslint.rules.semi" />
   </file>
+  <file name="lint-filter\test\fixtures\dummy.js">
+    <error line="11" column="14" severity="error" message="Extra semicolon. (semi)" source="eslint.rules.semi" />
+  </file>
 </checkstyle>

--- a/test/fixtures/eslint/extra-semi.xml
+++ b/test/fixtures/eslint/extra-semi.xml
@@ -7,4 +7,7 @@
     <error line="7" column="23" severity="error" message="Extra semicolon. (semi)" source="eslint.rules.semi" />
     <error line="7" column="23" severity="error" message="Extra semicolon. (semi)" source="eslint.rules.semi" />
   </file>
+  <file name="lint-filter/src/index.js">
+    <error line="7" column="23" severity="error" message="Extra semicolon. (semi)" source="eslint.rules.semi" />
+  </file>
 </checkstyle>

--- a/test/parser_tests.js
+++ b/test/parser_tests.js
@@ -40,6 +40,13 @@ const parseStringResult = [
     source: 'eslint.rules.semi',
     file: 'lint-filter/src/index.js',
   },
+  { line: '7',
+    column: '23',
+    severity: 'error',
+    message: 'Extra semicolon. (semi)',
+    source: 'eslint.rules.semi',
+    file: 'lint-filter/src/index.js',
+  },
 ]
 
 test.serial('parseString(str) should parse xml and make paths relative', async t => {


### PR DESCRIPTION
The current code cuts the first character out of the file path, if the path is relative instead of absolute